### PR TITLE
Fix compiler autodetection and update to 1.7.0

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,4 +1,4 @@
-MESON_VERSION='1.6.0'
+MESON_VERSION='1.7.0'
 
 export ZOPEN_STABLE_URL='https://github.com/mesonbuild/meson.git'
 export ZOPEN_STABLE_TAG="${MESON_VERSION}"

--- a/patches/mesonbuild/backend/backends.py.patch
+++ b/patches/mesonbuild/backend/backends.py.patch
@@ -1,8 +1,8 @@
 diff --git a/mesonbuild/backend/backends.py b/mesonbuild/backend/backends.py
-index 079b62dbd..15eecd1cc 100644
+index 18caf7bbe..8ecdaa037 100644
 --- a/mesonbuild/backend/backends.py
 +++ b/mesonbuild/backend/backends.py
-@@ -1279,7 +1279,7 @@ class Backend:
+@@ -1290,7 +1290,7 @@ class Backend:
                  ld_lib_path: T.Set[str] = set(os.path.join(env_build_dir, l.get_subdir()) for l in ld_lib_path_libs)
  
                  if ld_lib_path:
@@ -11,12 +11,3 @@ index 079b62dbd..15eecd1cc 100644
  
              ts = TestSerialisation(t.get_name(), t.project_name, t.suite, cmd, is_cross,
                                     exe_wrapper, self.environment.need_exe_wrapper(),
-@@ -2025,6 +2025,8 @@ class Backend:
-                 extra_paths.update(library_paths)
-             elif host_machine.is_darwin():
-                 env.prepend('DYLD_LIBRARY_PATH', list(library_paths))
-+            elif host_machine.is_zos():
-+                env.prepend('LIBPATH', list(library_paths))
-             else:
-                 env.prepend('LD_LIBRARY_PATH', list(library_paths))
-         if extra_paths:

--- a/patches/mesonbuild/build.py.patch
+++ b/patches/mesonbuild/build.py.patch
@@ -1,12 +1,13 @@
 diff --git a/mesonbuild/build.py b/mesonbuild/build.py
-index 460ed549b..e1f4da4f9 100644
+index c72857d2c..26bcda256 100644
 --- a/mesonbuild/build.py
 +++ b/mesonbuild/build.py
-@@ -2348,6 +2348,15 @@ class SharedLibrary(BuildTarget):
+@@ -2377,6 +2377,16 @@ class SharedLibrary(BuildTarget):
              suffix = 'so'
              # Android doesn't support shared_library versioning
              self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
 +        elif self.environment.machines[self.for_machine].is_zos():
++            # A z/OS PDSE member name if uppercase and up to 8 characters.
 +            if len(self.name) <= 8 and self.name.isupper() and not self.prefix and not self.suffix:
 +                prefix = ''
 +                self.filename_tpl = '{0.name}'
@@ -18,7 +19,7 @@ index 460ed549b..e1f4da4f9 100644
          else:
              prefix = 'lib'
              suffix = 'so'
-@@ -2730,7 +2739,7 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
+@@ -2771,7 +2781,7 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
              return self.depfile
  
      def is_linkable_output(self, output: str) -> bool:

--- a/patches/mesonbuild/compilers/compilers.py.patch
+++ b/patches/mesonbuild/compilers/compilers.py.patch
@@ -1,5 +1,5 @@
 diff --git a/mesonbuild/compilers/compilers.py b/mesonbuild/compilers/compilers.py
-index 603a3eb48..f4ef959f4 100644
+index 424bcc19b..a1f4929f1 100644
 --- a/mesonbuild/compilers/compilers.py
 +++ b/mesonbuild/compilers/compilers.py
 @@ -47,7 +47,7 @@ Also add corresponding autodetection code in detect.py."""

--- a/patches/mesonbuild/compilers/detect.py.patch
+++ b/patches/mesonbuild/compilers/detect.py.patch
@@ -1,8 +1,28 @@
 diff --git a/mesonbuild/compilers/detect.py b/mesonbuild/compilers/detect.py
-index 7542fb628..4dd2dcb22 100644
+index 7bd48d10c..811d8240d 100644
 --- a/mesonbuild/compilers/detect.py
 +++ b/mesonbuild/compilers/detect.py
-@@ -205,6 +205,8 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
+@@ -6,6 +6,7 @@ from __future__ import annotations
+ from ..mesonlib import (
+     MesonException, EnvironmentException, MachineChoice, join_args,
+     search_version, is_windows, Popen_safe, Popen_safe_logged, windows_proof_rm,
++    is_zos,
+ )
+ from ..envconfig import BinaryTable
+ from .. import mlog
+@@ -56,6 +57,11 @@ else:
+         defaults['cpp'] = ['c++', 'g++', 'l++', 'clang++']
+         defaults['objc'] = ['clang']
+         defaults['objcpp'] = ['clang++']
++    elif is_zos():
++        defaults['c'] = ['ibm-clang', 'ibm-clang64']
++        defaults['cpp'] = ['ibm-clang++', 'ibm-clang++64']
++        defaults['objc'] = []
++        defaults['objcpp'] = []
+     else:
+         defaults['c'] = ['cc', 'gcc', 'clang', 'nvc', 'pgcc', 'icc', 'icx']
+         defaults['cpp'] = ['c++', 'g++', 'clang++', 'nvc++', 'pgc++', 'icpc', 'icpx']
+@@ -206,6 +212,8 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
          except OSError as e:
              popen_exceptions[join_args(linker + [arg])] = e
              continue
@@ -11,19 +31,3 @@ index 7542fb628..4dd2dcb22 100644
          if "xilib: executing 'lib'" in err:
              return linkers.IntelVisualStudioLinker(linker, getattr(compiler, 'machine', None))
          if '/OUT:' in out.upper() or '/OUT:' in err.upper():
-@@ -447,7 +449,14 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
-                 return cls(
-                     ccache, compiler, version, for_machine, is_cross, info,
-                     full_version=full_version, linker=linker)
--
-+        if 'z/OS' in out:
-+            defines = _get_clang_compiler_defines(compiler, lang)
-+            cls = c.ClangCCompiler if lang == 'c' else cpp.ClangCPPCompiler
-+            env.coredata.add_lang_args(cls.language, cls, for_machine, env)
-+            linker = linkers.ZOSDynamicLinker(compiler, for_machine, cls.LINKER_PREFIX, [])
-+            return cls(
-+                ccache, compiler, version, for_machine, is_cross, info,
-+                full_version=full_version, linker=linker)
-         if 'clang' in out or 'Clang' in out:
-             linker = None
- 

--- a/patches/mesonbuild/compilers/detect.py.patch
+++ b/patches/mesonbuild/compilers/detect.py.patch
@@ -1,5 +1,5 @@
 diff --git a/mesonbuild/compilers/detect.py b/mesonbuild/compilers/detect.py
-index 7bd48d10c..811d8240d 100644
+index 7bd48d10c..e760b35ac 100644
 --- a/mesonbuild/compilers/detect.py
 +++ b/mesonbuild/compilers/detect.py
 @@ -6,6 +6,7 @@ from __future__ import annotations
@@ -15,8 +15,8 @@ index 7bd48d10c..811d8240d 100644
          defaults['objc'] = ['clang']
          defaults['objcpp'] = ['clang++']
 +    elif is_zos():
-+        defaults['c'] = ['ibm-clang', 'ibm-clang64']
-+        defaults['cpp'] = ['ibm-clang++', 'ibm-clang++64']
++        defaults['c'] = ['ibm-clang', 'ibm-clang64', 'clang', 'clang64']
++        defaults['cpp'] = ['ibm-clang++', 'ibm-clang++64', 'clang++', 'clang++64']
 +        defaults['objc'] = []
 +        defaults['objcpp'] = []
      else:

--- a/patches/mesonbuild/envconfig.py.patch
+++ b/patches/mesonbuild/envconfig.py.patch
@@ -1,48 +1,8 @@
 diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
-index 86bad9be2..a1397bc33 100644
+index 4055b2176..4a7c746c2 100644
 --- a/mesonbuild/envconfig.py
 +++ b/mesonbuild/envconfig.py
-@@ -64,6 +64,19 @@ known_cpu_families = (
-     'wasm64',
-     'x86',
-     'x86_64',
-+    # z/Architecture CPU Families
-+    '3932',
-+    '3931',
-+    '8562',
-+    '8561',
-+    '3907',
-+    '3906',
-+    '2965',
-+    '2964',
-+    '2828',
-+    '2827',
-+    '2818',
-+    '2817',
- )
- 
- # It would feel more natural to call this "64_BIT_CPU_FAMILIES", but
-@@ -81,6 +94,19 @@ CPU_FAMILIES_64_BIT = [
-     'sw_64',
-     'wasm64',
-     'x86_64',
-+    # z/Architecture CPU Families
-+    '3932',
-+    '3931',
-+    '8562',
-+    '8561',
-+    '3907',
-+    '3906',
-+    '2965',
-+    '2964',
-+    '2828',
-+    '2827',
-+    '2818',
-+    '2817',
- ]
- 
- # Map from language identifiers to environment variables.
-@@ -362,6 +388,12 @@ class MachineInfo(HoldableObject):
+@@ -363,6 +363,12 @@ class MachineInfo(HoldableObject):
          """
          return self.system == 'aix'
  
@@ -50,7 +10,7 @@ index 86bad9be2..a1397bc33 100644
 +        """
 +        Machine is z/OS?
 +        """
-+        return self.system == 'os/390'
++        return self.system == 'zos'
 +
      def is_irix(self) -> bool:
          """Machine is IRIX?"""

--- a/patches/mesonbuild/environment.py.patch
+++ b/patches/mesonbuild/environment.py.patch
@@ -1,0 +1,58 @@
+diff --git a/mesonbuild/environment.py b/mesonbuild/environment.py
+index c09d7e312..5dad6377b 100644
+--- a/mesonbuild/environment.py
++++ b/mesonbuild/environment.py
+@@ -363,6 +363,8 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
+         trial = detect_windows_arch(compilers)
+     elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_qnx() or mesonlib.is_aix():
+         trial = platform.processor().lower()
++    elif mesonlib.is_zos():
++        trial = 's390x'
+     else:
+         trial = platform.machine().lower()
+     if trial.startswith('i') and trial.endswith('86'):
+@@ -429,6 +431,8 @@ def detect_cpu(compilers: CompilersDict) -> str:
+         trial = detect_windows_arch(compilers)
+     elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_aix():
+         trial = platform.processor().lower()
++    elif mesonlib.is_zos():
++        trial = 's390x'
+     else:
+         trial = platform.machine().lower()
+ 
+@@ -478,6 +482,7 @@ KERNEL_MAPPINGS: T.Mapping[str, str] = {'freebsd': 'freebsd',
+                                         'dragonfly': 'dragonfly',
+                                         'haiku': 'haiku',
+                                         'gnu': 'gnu',
++                                        'zos': 'zos',
+                                         }
+ 
+ def detect_kernel(system: str) -> T.Optional[str]:
+@@ -508,6 +513,8 @@ def detect_subsystem(system: str) -> T.Optional[str]:
+ def detect_system() -> str:
+     if sys.platform == 'cygwin':
+         return 'cygwin'
++    if sys.platform == 'zos':
++        return 'zos'
+     return platform.system().lower()
+ 
+ def detect_msys2_arch() -> T.Optional[str]:
+@@ -547,7 +554,8 @@ def machine_info_can_run(machine_info: MachineInfo):
+     return \
+         (machine_info.cpu_family == true_build_cpu_family) or \
+         ((true_build_cpu_family == 'x86_64') and (machine_info.cpu_family == 'x86')) or \
+-        ((true_build_cpu_family == 'mips64') and (machine_info.cpu_family == 'mips'))
++        ((true_build_cpu_family == 'mips64') and (machine_info.cpu_family == 'mips')) or \
++        ((true_build_cpu_family == 's390x') and (machine_info.cpu_family == 's390'))
+ 
+ class Environment:
+     private_dir = 'meson-private'
+@@ -1019,6 +1027,8 @@ class Environment:
+                 extra_paths.update(library_paths)
+             elif self.machines.host.is_darwin():
+                 env.prepend('DYLD_LIBRARY_PATH', list(library_paths))
++            elif self.machines.host.is_zos():
++                env.prepend('LIBPATH', list(library_paths))
+             else:
+                 env.prepend('LD_LIBRARY_PATH', list(library_paths))
+         if extra_paths:

--- a/patches/mesonbuild/linkers/detect.py.patch
+++ b/patches/mesonbuild/linkers/detect.py.patch
@@ -1,0 +1,21 @@
+diff --git a/mesonbuild/linkers/detect.py b/mesonbuild/linkers/detect.py
+index 493430a87..5d6b2dbb2 100644
+--- a/mesonbuild/linkers/detect.py
++++ b/mesonbuild/linkers/detect.py
+@@ -215,6 +215,16 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
+         linker = linkers.AIXDynamicLinker(
+             compiler, for_machine, comp_class.LINKER_PREFIX, override,
+             version=search_version(e))
++    elif 'IEW5033' in e:
++        if isinstance(comp_class.LINKER_PREFIX, str):
++            _, o, e = Popen_safe(compiler + [comp_class.LINKER_PREFIX + '-V'] + extra_args)
++        else:
++            _, o, e = Popen_safe(compiler + comp_class.LINKER_PREFIX + ['-V'] + extra_args)
++        version = re.search(r'z/OS (V\d+ R\d+) BINDER', o)
++        version = 'unknown version' if version is None else version.group(1)
++        linker = linkers.ZOSDynamicLinker(
++            compiler, for_machine, comp_class.LINKER_PREFIX, override,
++            version=version)
+     elif o.startswith('zig ld'):
+         linker = linkers.ZigCCDynamicLinker(
+             compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)

--- a/patches/mesonbuild/linkers/linkers.py.patch
+++ b/patches/mesonbuild/linkers/linkers.py.patch
@@ -1,8 +1,8 @@
 diff --git a/mesonbuild/linkers/linkers.py b/mesonbuild/linkers/linkers.py
-index c4df0fa1d..1316d22d1 100644
+index 176fb3348..f0fd70ce0 100644
 --- a/mesonbuild/linkers/linkers.py
 +++ b/mesonbuild/linkers/linkers.py
-@@ -391,6 +391,10 @@ class ArLinker(ArLikeLinker, StaticLinker):
+@@ -394,6 +394,10 @@ class ArLinker(ArLikeLinker, StaticLinker):
              return self.std_args
  
  
@@ -13,17 +13,17 @@ index c4df0fa1d..1316d22d1 100644
  class AppleArLinker(ArLinker):
  
      # mostly this is used to determine that we need to call ranlib
-@@ -753,6 +757,13 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
-         return self._apply_prefix(args)
+@@ -1571,6 +1575,13 @@ class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+         return ['-pthread']
  
  
 +class ZOSDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 +
 +    """z/OS ld implementation."""
 +
-+    id = "ldz"
++    id = "ld.zos"
 +
 +
- class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+ class OptlinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
  
-     """Apple's ld implementation."""
+     """Digital Mars dynamic linker for windows."""

--- a/patches/mesonbuild/utils/universal.py.patch
+++ b/patches/mesonbuild/utils/universal.py.patch
@@ -1,8 +1,8 @@
 diff --git a/mesonbuild/utils/universal.py b/mesonbuild/utils/universal.py
-index 88d8e1f89..c980b202b 100644
+index 3ec23e105..bd9e49751 100644
 --- a/mesonbuild/utils/universal.py
 +++ b/mesonbuild/utils/universal.py
-@@ -122,6 +122,7 @@ __all__ = [
+@@ -125,6 +125,7 @@ __all__ = [
      'is_openbsd',
      'is_osx',
      'is_qnx',
@@ -10,7 +10,7 @@ index 88d8e1f89..c980b202b 100644
      'is_sunos',
      'is_windows',
      'is_wsl',
-@@ -622,6 +623,10 @@ class PerThreeMachineDefaultable(PerMachineDefaultable[T.Optional[_T]], PerThree
+@@ -629,6 +630,10 @@ class PerThreeMachineDefaultable(PerMachineDefaultable[T.Optional[_T]], PerThree
          return f'PerThreeMachineDefaultable({self.build!r}, {self.host!r}, {self.target!r})'
  
  


### PR DESCRIPTION
Rebased onto 1.7.0.

Fixes the compiler detection for Open XL C/C++ and z/OS `ld` including version detection. Additionally, the system and cpu_family strings are now correctly normalised to `zos` and `s390x`.

The updated system/cpu_family strings may be a breaking change if they are used for platform detection, if anyone is currently doing so.