### PR TITLE
improve portability with Python zipapp packaging

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -45,40 +45,15 @@ zopen_get_version() {
 }
 
 zopen_build() {
-    python -m venv .venv
-    . .venv/bin/activate
-    pip install setuptools build installer wheel && \
-    rm -rf dist && \
-    python -m build --wheel
-    zopen_build_result="$?"
-    deactivate
-    return "$zopen_build_result"
+    ./packaging/create_zipapp.py --outfile meson.pyz --interpreter '/usr/bin/env python3'
 }
 
 zopen_check() {
-    . .venv/bin/activate
-    python run_tests.py
-    zopen_check_result="$?"
-    deactivate
-    return "$zopen_check_result"
+    python3 run_tests.py
+    return "$?"
 }
 
 zopen_install() {
-    set -e
-    mkdir -p "${ZOPEN_INSTALL_DIR}/lib/"
-    cp "dist/meson-${MESON_VERSION}-py3-none-any.whl" "${ZOPEN_INSTALL_DIR}/lib/"
     mkdir -p "${ZOPEN_INSTALL_DIR}/bin/"
-    touch "${ZOPEN_INSTALL_DIR}/bin/meson"
-    set +e
-}
-
-zopen_append_to_setup() {
-    echo "python -m pip install --prefix=. 'lib/meson-${MESON_VERSION}-py3-none-any.whl'"
-}
-
-zopen_append_to_env() {
-    cat <<EOF
-PYTHONPATH="\$PYTHONPATH:\$(python -c 'import site; import os; site.PREFIXES=[os.getcwd()]; print(site.getsitepackages()[0])')"
-export PYTHONPATH="\$(deleteDuplicateEntries "\$PYTHONPATH" ":")"
-EOF
+    cp meson.pyz "${ZOPEN_INSTALL_DIR}/bin/meson"
 }


### PR DESCRIPTION
Fixes the Meson shebang containing a hardcoded path for a specific Python version. The previous way wasn't great as it would break when a site upgrades Python.

Unfortunately it adds ~1.2s of real startup time on my system.